### PR TITLE
Debian package version can be now specified through an Ansible var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 mesos_install_mode: "master" # {master|slave|master-slave}
 mesos_version: "0.21.0"
+mesos_package_version: "1.0"
 
 # conf file settings
 mesos_cluster_name: "mesos_cluster"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -13,4 +13,4 @@
     - unzip
     - python-setuptools
     - python-dev
-    - mesos={{mesos_version}}-1.0.{{ansible_distribution|lower}}{{ansible_distribution_version.split('.')|join('')}}
+    - mesos={{mesos_version}}-{{mesos_package_version}}.{{ansible_distribution|lower}}{{ansible_distribution_version.split('.')|join('')}}


### PR DESCRIPTION
I wanted to install Ubuntu Mesos package `Version: 0.24.1-0.2.35.ubuntu1404` since i was having stability issues with previous versions (Ubuntu 14.04) through this role, but wasn't possible since the package version was hardcoded, so i added an Ansible variable for it. Sample playbook snip:

```
    - { role: ansible-mesos, mesos_version: "0.24.1", mesos_package_version: "0.2.35", mesos_install_mode: "master-slave", mesos_containerizers: "docker,mesos", tags: ['mesos', 'platforms'] }
```