### PR TITLE
Fix running user when using systemd.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ mesos_quorum: "1"
 zookeeper_client_port: "2181"
 zookeeper_hostnames: "{{ mesos_hostname }}:{{ zookeeper_client_port }}"
 mesos_zookeeper_masters: "zk://{{ zookeeper_hostnames }}/mesos"
+mesos_owner: root
+mesos_group: root
 
 # Containerizer
 mesos_containerizers: "mesos"

--- a/templates/mesos-master.service.j2
+++ b/templates/mesos-master.service.j2
@@ -5,8 +5,8 @@ Description=mesos master
 
 [Service]
 Type=simple
-User=mesos
-Group=mesos
+User={{ mesos_owner }}
+Group={{ mesos_group }}
 ExecStart=/usr/bin/mesos-init-wrapper master
 TimeoutSec=300
 

--- a/templates/mesos-slave.service.j2
+++ b/templates/mesos-slave.service.j2
@@ -5,8 +5,8 @@ Description=mesos slave
 
 [Service]
 Type=simple
-User=mesos
-Group=mesos
+User={{ mesos_owner }}
+Group={{ mesos_group }}
 ExecStart=/usr/bin/mesos-init-wrapper slave
 TimeoutSec=300
 


### PR DESCRIPTION
Found out user `mesos` doesn't exist, was assumed to be created by mesosphere package. Now the user is `root` by default. Affects only when OS uses systemd.