### PR TITLE
systemd daemons reload and yum repos URL variable move

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ mesosphere_yum_repo: "http://repos.mesosphere.com/el/{{ os_version_major }}/noar
 # conf file settings
 mesos_cluster_name: "mesos_cluster"
 mesos_ip: "{{ansible_default_ipv4.address}}"
-mesos_hostname: "{{ inventory_hostname }}"
+mesos_hostname: "{{ ansible_hostname }}"
 mesos_master_port: "5050"
 mesos_slave_port: "5051"
 mesos_log_location: "/var/log/mesos"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ mesos_version: "0.21.0"
 
 # Debian
 mesos_package_version: "1.0"
-mesosphere_deb_url: "http://repos.mesosphere.com/{{ ansible_distribution | lower }}"
+mesosphere_apt_url: "http://repos.mesosphere.com/{{ ansible_distribution | lower }}"
 
 # RedHat: EPEL and Mesosphere yum repositories URL
 epel_repo: "http://dl.fedoraproject.org/pub/epel/{{ os_version_major }}/{{ ansible_architecture }}/{{ epel_releases[os_version_major] }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,19 @@
 ---
 mesos_install_mode: "master" # {master|slave|master-slave}
 mesos_version: "0.21.0"
+
+# Debian
 mesos_package_version: "1.0"
+mesosphere_deb_url: "http://repos.mesosphere.com/{{ ansible_distribution | lower }}"
+
+# RedHat: EPEL and Mesosphere yum repositories URL
+epel_repo: "http://dl.fedoraproject.org/pub/epel/{{ os_version_major }}/{{ ansible_architecture }}/{{ epel_releases[os_version_major] }}"
+mesosphere_yum_repo: "http://repos.mesosphere.com/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
 
 # conf file settings
 mesos_cluster_name: "mesos_cluster"
 mesos_ip: "{{ansible_default_ipv4.address}}"
-mesos_hostname: "{{ ansible_hostname }}"
+mesos_hostname: "{{ inventory_hostname }}"
 mesos_master_port: "5050"
 mesos_slave_port: "5051"
 mesos_log_location: "/var/log/mesos"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,14 @@
 ---
+
+# While waiting for https://github.com/ansible/ansible-modules-core/issues/191
+- name: Reload daemon
+  command: systemctl daemon-reload
+  
 # i.e. upgrade mesos, templates stay the same...
 - name: Restart mesos-master
   service: name=mesos-master state=restarted
+  when: mesos_install_mode == "master" or mesos_install_mode == "master-slave"
 
 - name: Restart mesos-slave 
   service: name=mesos-slave state=restarted
+  when: mesos_install_mode == "slave" or mesos_install_mode == "master-slave"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -3,7 +3,7 @@
   apt_key: id=E56151BF keyserver=keyserver.ubuntu.com state=present
 
 - name: Add mesosphere repo
-  apt_repository: repo='deb {{ mesosphere_deb_url }} {{ansible_distribution_release|lower}} main' state=present
+  apt_repository: repo='deb {{ mesosphere_apt_url }} {{ansible_distribution_release|lower}} main' state=present
 
 - name: Install Debian OS packages
   apt: pkg={{item}} state=present update_cache=yes

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -3,7 +3,7 @@
   apt_key: id=E56151BF keyserver=keyserver.ubuntu.com state=present
 
 - name: Add mesosphere repo
-  apt_repository: repo='deb http://repos.mesosphere.io/{{ansible_distribution|lower}} {{ansible_distribution_release|lower}} main' state=present
+  apt_repository: repo='deb {{ mesosphere_deb_url }} {{ansible_distribution_release|lower}} main' state=present
 
 - name: Install Debian OS packages
   apt: pkg={{item}} state=present update_cache=yes

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Add mesosphere repo
-  yum: name={{ mesosphere_repo }} state=present
+  yum: name={{ mesosphere_yum_repo }} state=present
 
 - name: Downloading and enable the EPEL repository definitions.
   yum: name={{ epel_repo }} state=present

--- a/tasks/mesos.yml
+++ b/tasks/mesos.yml
@@ -59,11 +59,13 @@
   template: src=mesos-master.service.j2 dest=/usr/lib/systemd/system/mesos-master.service
   when: (mesos_install_mode == "master" or mesos_install_mode == "master-slave") and systemd_check.stat.exists == true
   notify:
+    - Reload daemon
     - Restart mesos-master
 
 - name: Mesos slave systemd script
   template: src=mesos-slave.service.j2 dest=/usr/lib/systemd/system/mesos-slave.service
   when: (mesos_install_mode == "slave" or mesos_install_mode == "master-slave") and systemd_check.stat.exists == true
   notify:
+    - Reload daemon
     - Restart mesos-slave
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,12 +6,8 @@ epel_releases:
   '6': 'epel-release-6-8.noarch.rpm'
   '7': 'e/epel-release-7-5.noarch.rpm'
 
-epel_repo: "http://dl.fedoraproject.org/pub/epel/{{ os_version_major }}/{{ ansible_architecture }}/{{ epel_releases[os_version_major] }}"
-
 # Mesosphere released packaged per OS version
 mesosphere_releases:
   '6': 'mesosphere-el-repo-6-3.noarch.rpm'
   '7': 'mesosphere-el-repo-7-1.noarch.rpm'
-
-mesosphere_repo: "http://repos.mesosphere.com/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-mesos_playbook_version: "0.3.3"
+mesos_playbook_version: "0.3.4"


### PR DESCRIPTION
Change to systemd scripts (e.g. `/usr/lib/systemd/system/mesos-master.service`) isn't being picked by systemd because `service` module `restarted` state doesn't reload daemon/service script. There's an open issue for that https://github.com/ansible/ansible-modules-core/issues/191

Also add condition on handler to make sure restart are done specifically for installation type of the host. For some unknown reason bot handler get called even though the installation type is master only.

Also move EPEL and Mesosphere yum repos URL to defaults to allow overriding for organization where packaged are managed (no Internet connection allowed)