### PR TITLE
Limit handler calls to respective host modes

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,8 @@
 # i.e. upgrade mesos, templates stay the same...
 - name: Restart mesos-master
   service: name=mesos-master state=restarted
+  when: mesos_install_mode == "master" or mesos_install_mode == "master-slave"
 
 - name: Restart mesos-slave 
   service: name=mesos-slave state=restarted
+  when: mesos_install_mode == "slave" or mesos_install_mode == "master-slave"


### PR DESCRIPTION
Otherwise, when /etc/default/mesos is changed, it fires off both handlers.