### PR TITLE
Add support for resources and attributes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,13 @@ mesos_additional_configs: []
   # For example:
   # - name: FOO
   #   value: bar
+
+# A dictionary of attributes which the Mesos slave node passes along when it sends offers
+mesos_attributes: {}
+  # rack_id: 1
+  # os: centos7
+
+# A dictionary of resources which the Mesos slave node should offer
+mesos_resources: {}
+  # ports(*): "[31000-32000]"
+  # ports(marathon): "[8000-9000]"

--- a/tasks/mesos.yml
+++ b/tasks/mesos.yml
@@ -15,6 +15,11 @@
 
 - name: Remove Default Mesos-Slave Config
   file: state=absent path=/etc/mesos-slave/
+  when: mesos_install_mode == "master"
+
+- name: Create Mesos-Slave Config Dir
+  file: state=directory path=/etc/mesos-slave/
+  when: '"slave" in mesos_install_mode'
 
 # == Configure and recreate
 - name: Mesos default config file
@@ -32,6 +37,22 @@
 - name: Mesos Slave config file
   template: src=conf-mesos-slave.j2 dest=/etc/default/mesos-slave
   when: mesos_install_mode == "slave" or mesos_install_mode == "master-slave"
+  notify:
+    - Restart mesos-slave
+
+- name: Mesos Slave attributes file
+  template: src=attributes-mesos-slave.j2 dest=/etc/mesos-slave/attributes
+  when:
+    - '"slave" in mesos_install_mode'
+    - mesos_attributes
+  notify:
+    - Restart mesos-slave
+
+- name: Mesos Slave resources file
+  template: src=resources-mesos-slave.j2 dest=/etc/mesos-slave/resources
+  when:
+    - '"slave" in mesos_install_mode'
+    - mesos_resources
   notify:
     - Restart mesos-slave
 

--- a/templates/attributes-mesos-slave.j2
+++ b/templates/attributes-mesos-slave.j2
@@ -1,0 +1,1 @@
+{% for k,v in mesos_attributes.iteritems() %}{{ k }}:{{ v }}{% if not loop.last %};{% endif%}{% endfor %}

--- a/templates/resources-mesos-slave.j2
+++ b/templates/resources-mesos-slave.j2
@@ -1,0 +1,1 @@
+{% for k,v in mesos_resources.iteritems() %}{{ k }}:{{ v }}{% if not loop.last %};{% endif %}{% endfor %}


### PR DESCRIPTION
Adds the variables `mesos_resources` and `mesos_attributes` which are templated into `/etc/mesos-slave/resources` and `/etc/mesos-slave/attributes`, respectively.

I'm not exactly sure how to handle the case where attributes/resources are modified for a running Mesos Slave, because with checkpointing enabled (the default), the service will fail to restart with the message "Failed to perform recovery: Incompatible slave info detected.".  In my testing, setting `strict=false` did not help in this case either. The only thing which seemed to work for me was wiping out the meta directory in /var/mesos and then restarting the service. We could potentially do this as a notifier, but it seems a bit heavy handed.

Feedback welcome.

Closes #40