### PR TITLE
Add improvements to systemd unit files

### DIFF
--- a/templates/mesos-master.service.j2
+++ b/templates/mesos-master.service.j2
@@ -2,13 +2,16 @@
 
 [Unit]
 Description=mesos master
+After=network.target
+Wants=network.target
 
 [Service]
-Type=simple
+ExecStart=/usr/bin/mesos-init-wrapper master
+Restart=always
+RestartSec=20
+TimeoutSec=300
 User={{ mesos_owner }}
 Group={{ mesos_group }}
-ExecStart=/usr/bin/mesos-init-wrapper master
-TimeoutSec=300
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/mesos-slave.service.j2
+++ b/templates/mesos-slave.service.j2
@@ -2,13 +2,17 @@
 
 [Unit]
 Description=mesos slave
+After=network.target
+Wants=network.target
 
 [Service]
-Type=simple
+ExecStart=/usr/bin/mesos-init-wrapper slave
+KillMode=process
+Restart=always
+RestartSec=20
+TimeoutSec=300
 User={{ mesos_owner }}
 Group={{ mesos_group }}
-ExecStart=/usr/bin/mesos-init-wrapper slave
-TimeoutSec=300
 
 [Install]
 WantedBy=multi-user.target

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-mesos_playbook_version: "0.3.4"
+mesos_playbook_version: "0.3.5"


### PR DESCRIPTION
This commit introduces changes to the systemd unit files for Mesos Master and
Slave. We're now more closely mirroring the configurations used in the
Mesosphere distributions[1]:

 - Start after network.target
 - Restart=always with RestartSec=20
 - Set KillMode=process for Slave processes

I left out the CPU and Memory accounting features because I don't know how they
are used, and from what I've read there may be some compatibility issues with
RHEL/CentOS 7.

[1]: https://github.com/mesosphere/mesos-deb-packaging/tree/master/systemd