### PR TITLE
Fix RedHat os version parsing & epel release

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,10 +1,9 @@
-os_version: "{{ ansible_lsb.release if ansible_lsb is defined else ansible_distribution_version }}"
-os_version_major: "{{ os_version | regex_replace('^([0-9]+)[^0-9]*.*', '\\\\1') }}"
+os_version_major: "{{ ansible_distribution_major_version }}"
 
 # EPEL repository released packaged per OS version
 epel_releases:
   '6': 'epel-release-6-8.noarch.rpm'
-  '7': 'e/epel-release-7-5.noarch.rpm'
+  '7': 'e/epel-release-7-6.noarch.rpm'
 
 # Mesosphere released packaged per OS version
 mesosphere_releases:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-mesos_playbook_version: "0.3.5"
+mesos_playbook_version: "0.3.6"


### PR DESCRIPTION
@JasonGiedymin 

I have found the following bugs:

 - os_version_major parsing
 - epel-release-7-5.noarch.rpm package not found

os_version_major parsing fails with

```bash
 TASK [ansible-mesos : debug] ***************************************************
       task path: /tmp/kitchen/roles/ansible-mesos/tasks/RedHat.yml:2
       fatal: [localhost]: FAILED! => {"failed": true, "msg": "'dict object' has no attribute u'\\\\1'"}
       	to retry, use: --limit @/tmp/kitchen/default.retry
```
