### PR TITLE
Use HTTPS for repository URLs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,8 @@ mesos_package_version: "0.2.70"
 mesosphere_apt_url: "http://repos.mesosphere.com/{{ ansible_distribution | lower }}"
 
 # RedHat: EPEL and Mesosphere yum repositories URL
-epel_repo: "http://dl.fedoraproject.org/pub/epel/{{ os_version_major }}/{{ ansible_architecture }}/{{ epel_releases[os_version_major] }}"
-mesosphere_yum_repo: "http://repos.mesosphere.com/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
+epel_repo: "https://dl.fedoraproject.org/pub/epel/{{ os_version_major }}/{{ ansible_architecture }}/{{ epel_releases[os_version_major] }}"
+mesosphere_yum_repo: "https://repos.mesosphere.com/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
 
 # conf file settings
 mesos_cluster_name: "mesos_cluster"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Add apt-key
-  apt_key: id=E56151BF keyserver=keyserver.ubuntu.com state=present
+  apt_key: id=DF7D54CBE56151BF keyserver=keyserver.ubuntu.com state=present
 
 - name: Add mesosphere repo
   apt_repository: repo='deb {{ mesosphere_apt_url }} {{ansible_distribution_release|lower}} main' state=present


### PR DESCRIPTION
### Short description:

RPM packages should be installed over HTTPS to prevent MITM attacks.

Apt is less susceptible since all packages are signed and verified, but
we should rely on the long key IDs instead of short ones to reduce the
chance of an OpenPGP key ID collision.

Closes #47 

### Bookkeeping
I did the following bookkeeping:
 - [ ] If a major change, bumped the playbook version in `vars/`
 - [ ] Added as much documentation as I could (we're not looking a book, just enough to help others)
 - [x] Confirmed that the PR works by running the vagrant tests (if any) and/or added to the tests (see `ci/` or legacy `tests/`)
 - [ ] Followed up with any automated test results as a result of the pull request