### PR TITLE
Allow additional mesos master and slave configs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,3 +38,14 @@ mesos_additional_configs: []
   # - name: FOO
   #   value: bar
 
+# Additional configurations for master
+mesos_master_additional_configs: []
+  # For example:
+  # - name: FOO
+  #   value: bar
+
+# Additional configurations for slave
+mesos_slave_additional_configs: []
+  # For example:
+  # - name: FOO
+  #   value: bar

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,8 @@ mesos_group: root
 mesos_containerizers: "mesos"
 mesos_executor_timeout: "5mins"
 
+mesos_option_prefix: "MESOS_"
+
 # Additional configurations
 mesos_additional_configs: []
   # For example:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,4 +11,4 @@
 - include: RedHat.yml
   when: ansible_os_family == "RedHat"
 
-- include: mesos.yml
+- include: mesos.yml tags=configuration

--- a/templates/conf-mesos-master.j2
+++ b/templates/conf-mesos-master.j2
@@ -3,3 +3,8 @@
 export MESOS_QUORUM="{{ mesos_quorum }}"
 export MESOS_WORK_DIR="{{ mesos_work_dir }}"
 export MESOS_PORT="{{ mesos_master_port }}"
+
+# Additional configs
+{% for config_item in mesos_master_additional_configs %}
+export MESOS_{{config_item.name}}={{config_item.value}}
+{% endfor %}

--- a/templates/conf-mesos-master.j2
+++ b/templates/conf-mesos-master.j2
@@ -6,5 +6,5 @@ export MESOS_PORT="{{ mesos_master_port }}"
 
 # Additional configs
 {% for config_item in mesos_master_additional_configs %}
-export MESOS_{{config_item.name}}={{config_item.value}}
+export {{mesos_option_prefix}}{{config_item.name}}={{config_item.value}}
 {% endfor %}

--- a/templates/conf-mesos-slave.j2
+++ b/templates/conf-mesos-slave.j2
@@ -8,5 +8,5 @@ export MESOS_WORK_DIR="{{ mesos_work_dir }}"
 
 # Additional configs
 {% for config_item in mesos_slave_additional_configs %}
-export MESOS_{{config_item.name}}={{config_item.value}}
+export {{mesos_option_prefix}}{{config_item.name}}={{config_item.value}}
 {% endfor %}

--- a/templates/conf-mesos-slave.j2
+++ b/templates/conf-mesos-slave.j2
@@ -5,3 +5,8 @@ export MESOS_CONTAINERIZERS="{{ mesos_containerizers }}"
 export MESOS_EXECUTOR_REGISTRATION_TIMEOUT="{{ mesos_executor_timeout }}"
 export MESOS_PORT="{{ mesos_slave_port }}"
 export MESOS_WORK_DIR="{{ mesos_work_dir }}"
+
+# Additional configs
+{% for config_item in mesos_slave_additional_configs %}
+export MESOS_{{config_item.name}}={{config_item.value}}
+{% endfor %}

--- a/templates/conf-mesos.j2
+++ b/templates/conf-mesos.j2
@@ -13,6 +13,7 @@ ZK="{{ mesos_zookeeper_masters }}"
 export MESOS_HOSTNAME="{{ mesos_hostname }}"
 
 # Additional configs
+export MESOS_OPTION_PREFIX={{mesos_option_prefix}}
 {% for config_item in mesos_additional_configs %}
-export MESOS_{{config_item.name}}={{config_item.value}}
+export {{mesos_option_prefix}}{{config_item.name}}={{config_item.value}}
 {% endfor %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-mesos_playbook_version: "0.3.10"
+mesos_playbook_version: "0.4.0"


### PR DESCRIPTION
This allows very flexible additional configurations.

Example usage, that we use in prod. both for the master and slave:
```
  mesos_master_additional_configs:
  - name: MAX_COMPLETED_FRAMEWORKS
    value: 50
  - name: MAX_COMPLETED_TASKS_PER_FRAMEWORK
    value: 30

  mesos_slave_additional_configs:
  - name: RESOURCES
    value: "{{mesos_slave_resources}}"
  - name: HADOOP_HOME
    value: "{{hadoop_home}}"
```

@ernestas-poskus any chance to get a review and potential merge ?!