### PR TITLE
Update epel_release of CentOS 7 to 7-8 and bump version

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,7 +3,7 @@ os_version_major: "{{ ansible_distribution_major_version }}"
 # EPEL repository released packaged per OS version
 epel_releases:
   '6': 'epel-release-6-8.noarch.rpm'
-  '7': 'e/epel-release-7-7.noarch.rpm'
+  '7': 'e/epel-release-7-8.noarch.rpm'
 
 # Mesosphere released packaged per OS version
 mesosphere_releases:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-mesos_playbook_version: "0.3.9"
+mesos_playbook_version: "0.3.10"


### PR DESCRIPTION
### Short description:

I found the following issue(s) or bug(s):
  - Fail to download and enable epel repository definitions, return 404 error.

_And/OR_

I found that the following _enhancement_ is worthwhile:
  - The epel release has been updated to `epel-release-7-8.noarch.rpm` in 7/24/2016.

### Bookkeeping
I did the following bookkeeping:
 - [x] If a major change, bumped the playbook version in `vars/`
 - [ ] Added as much documentation as I could (we're not looking a book, just enough to help others)
 - [x] Confirmed that the PR works by running the vagrant tests (if any) and/or added to the tests (see `ci/` or legacy `tests/`)
 - [ ] Followed up with any automated test results as a result of the pull request

