### PR TITLE
Make installation of mesos on mesos more dynamic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ mesos_version: "0.25.0"
 # Debian
 mesos_package_version: "0.2.70"
 mesosphere_apt_url: "http://repos.mesosphere.com/{{ ansible_distribution | lower }}"
+mesos_os_distribution: "{{ ansible_distribution | lower }}"
+mesos_os_version: "{{ ansible_distribution_version.split('.') | join('') }}"
 
 # RedHat: EPEL and Mesosphere yum repositories URL
 epel_repo: "https://dl.fedoraproject.org/pub/epel/{{ os_version_major }}/{{ ansible_architecture }}/{{ epel_releases[os_version_major] }}"
@@ -12,7 +14,7 @@ mesosphere_yum_repo: "https://repos.mesosphere.com/el/{{ os_version_major }}/noa
 
 # conf file settings
 mesos_cluster_name: "mesos_cluster"
-mesos_ip: "{{ansible_default_ipv4.address}}"
+mesos_ip: "{{ ansible_default_ipv4.address }}"
 mesos_hostname: "{{ ansible_hostname }}"
 mesos_master_port: "5050"
 mesos_slave_port: "5051"
@@ -35,3 +37,4 @@ mesos_additional_configs: []
   # For example:
   # - name: FOO
   #   value: bar
+

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -13,4 +13,5 @@
     - unzip
     - python-setuptools
     - python-dev
-    - mesos={{mesos_version}}-{{mesos_package_version}}.{{ansible_distribution|lower}}{{ansible_distribution_version.split('.')|join('')}}
+    - mesos={{ mesos_version }}-{{ mesos_package_version }}.{{ mesos_os_distribution }}{{ mesos_os_version }}
+

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Add apt-key
-  apt_key: id=DF7D54CBE56151BF keyserver=keyserver.ubuntu.com state=present
+  apt_key: id=E56151BF keyserver=keyserver.ubuntu.com state=present
 
 - name: Add mesosphere repo
   apt_repository: repo='deb {{ mesosphere_apt_url }} {{ansible_distribution_release|lower}} main' state=present


### PR DESCRIPTION
### Short description:

I found the following issue(s) or bug(s):
  - installation on debian 8.5 not possible, because there are no apt-packages for that version. The latest one is for 8.1, what is totally fine, but the current yaml's demand version 8.5.

_And/OR_

I found that the following _enhancement_ is worthwhile:
  - The apt-key-id was not the latest one from the official installation guide from mesos for debian
