### PR TITLE
Fix containerization + Make APT-Package name more generic with varialbes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ mesos_package_version: "0.2.70"
 mesosphere_apt_url: "http://repos.mesosphere.com/{{ ansible_distribution | lower }}"
 mesos_os_distribution: "{{ ansible_distribution | lower }}"
 mesos_os_version: "{{ ansible_distribution_version.split('.') | join('') }}"
+mesos_apt_package: "mesos={{ mesos_version }}-{{ mesos_package_version }}.{{ mesos_os_distribution }}{{ mesos_os_version }}"
 
 # RedHat: EPEL and Mesosphere yum repositories URL
 epel_repo: "https://dl.fedoraproject.org/pub/epel/{{ os_version_major }}/{{ ansible_architecture }}/{{ epel_releases[os_version_major] }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ mesos_owner: root
 mesos_group: root
 
 # Containerizer
-mesos_containerizers: "mesos"
+mesos_containerizers: "docker,mesos"
 mesos_executor_timeout: "5mins"
 
 mesos_option_prefix: "MESOS_"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -3,15 +3,14 @@
   apt_key: id=E56151BF keyserver=keyserver.ubuntu.com state=present
 
 - name: Add mesosphere repo
-  apt_repository: repo='deb {{ mesosphere_apt_url }} {{ansible_distribution_release|lower}} main' state=present
+  apt_repository: repo='deb {{ mesosphere_apt_url }} {{ ansible_distribution_release | lower }} main' state=present
 
 - name: Install Debian OS packages
-  apt: pkg={{item}} state=present update_cache=yes
+  apt: pkg={{ item }} state=present update_cache=yes
   with_items:
     - wget
     - curl
     - unzip
     - python-setuptools
     - python-dev
-    - mesos={{ mesos_version }}-{{ mesos_package_version }}.{{ mesos_os_distribution }}{{ mesos_os_version }}
-
+    - "{{ mesos_apt_package }}"


### PR DESCRIPTION
### Short description:

I found the following issue(s) or bug(s):
  - "docker" was missing for containerization (https://mesosphere.github.io/marathon/docs/native-docker.html)

_And/OR_

I found that the following _enhancement_ is worthwhile:
  - Extract the whole "mesos=..." package name as variable