### PR TITLE
Always disable or enable the mesos-master and mesos-slave services

### DIFF
--- a/tasks/mesos.yml
+++ b/tasks/mesos.yml
@@ -69,10 +69,10 @@
     - Reload daemon
     - Restart mesos-slave
 
-- name: Disable mesos-master service
-  service: name=mesos-master enabled=no
-  when: mesos_install_mode == "slave" and systemd_check.stat.exists == true
+- name: Enable/Disable mesos-master service
+  service: name=mesos-master enabled="{{ (mesos_install_mode == 'slave') | ternary('no', 'yes') }}"
+  when: systemd_check.stat.exists == true
 
-- name: Disable mesos-slave service
-  service: name=mesos-slave enabled=no
-  when: mesos_install_mode == "master" and systemd_check.stat.exists == true
+- name: Enable/Disable mesos-slave service
+  service: name=mesos-slave enabled="{{ (mesos_install_mode == 'master') | ternary('no', 'yes') }}"
+  when: systemd_check.stat.exists == true


### PR DESCRIPTION
Depending on `mesos_install_mode` the master and/or slave services are disabled, but neither is actually being enabled (depending on `mesos_install_mode`).

With this change the services are always either enabled or disabled (explicitly).

Note that these services are not restarted twice ;)