### PR TITLE
configurable feature to avoid mesos-agent restart failing…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,9 @@ mesos_group: root
 mesos_containerizers: "docker,mesos"
 mesos_executor_timeout: "5mins"
 
+# If 'true' cleans symlink 'meta/slaves/latest' to avoid mesos-slave restart failures on config changes
+mesos_agent_meta_cleanup: false
+
 mesos_option_prefix: "MESOS_"
 
 # Additional configurations

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,6 +5,12 @@
   command: systemctl daemon-reload
   when: ansible_service_mgr == 'systemd'
 
+- name: Cleanup meta/slaves/latest
+  file: path="{{mesos_work_dir}}/meta/slaves/latest" state=absent
+  when:
+   - mesos_install_mode == "slave" or mesos_install_mode == "master-slave"
+   - mesos_agent_meta_cleanup
+
 # i.e. upgrade mesos, templates stay the same...
 - name: Restart mesos-master
   service: name=mesos-master state=restarted

--- a/tasks/mesos.yml
+++ b/tasks/mesos.yml
@@ -22,6 +22,7 @@
   notify:
     - Restart mesos-master
     - Restart mesos-slave
+    - Cleanup meta/slaves/latest
 
 - name: Mesos Master config file
   template: src=conf-mesos-master.j2 dest=/etc/default/mesos-master
@@ -34,6 +35,7 @@
   when: mesos_install_mode == "slave" or mesos_install_mode == "master-slave"
   notify:
     - Restart mesos-slave
+    - Cleanup meta/slaves/latest
 
 - name: Mesos master upstart script
   template: src=init-mesos-master.j2 dest=/etc/init/mesos-master.conf


### PR DESCRIPTION
… with "Incompatible agent info detected"

implements fix proposed for following issue(s) or bug(s):
https://github.com/AnsibleShipyard/ansible-mesos/issues/65

@ernestas-poskus I let you decide about any version bump!