### PR TITLE
Update cache after adding the repository, not before installing the package

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -3,10 +3,10 @@
   apt_key: id=E56151BF keyserver=keyserver.ubuntu.com state=present
 
 - name: Add mesosphere repo
-  apt_repository: repo='deb {{ mesosphere_apt_url }} {{ ansible_distribution_release | lower }} main' state=present
+  apt_repository: repo='deb {{ mesosphere_apt_url }} {{ ansible_distribution_release | lower }} main' state=present update_cache=yes
 
 - name: Install Debian OS packages
-  apt: pkg={{ item }} state=present update_cache=yes
+  apt: pkg={{ item }} state=present
   with_items:
     - wget
     - curl


### PR DESCRIPTION
When the repo is added, a update cache is required to be able install Marathon.

When installing/updating Marathon a cache update is not required, as the OS will keep the cache up-to-date.

This prevents changes when nothing actually changed (not idempotent).

(similar PR as https://github.com/AnsibleShipyard/ansible-marathon/pull/39)