### PR TITLE
Add SSL support to mesos configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ mesos_group: root
 mesos_containerizers: "docker,mesos"
 mesos_executor_timeout: "5mins"
 
+# SSL
+mesos_ssl_enabled: false
+mesos_ssl_support_downgrade: false
+mesos_ssl_key_file: # When SSL is enabled this must be used to point to the SSL key file
+mesos_ssl_cert_file: # When SSL is enabled this must be used to point to the SSL certificate file
+
 mesos_option_prefix: "MESOS_"
 
 # Additional configurations

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,10 @@ mesos_group: root
 mesos_containerizers: "docker,mesos"
 mesos_executor_timeout: "5mins"
 
+# SSL
+mesos_ssl_enabled: false
+mesos_ssl_support_downgrade: false
+
 # If 'true' cleans symlink 'meta/slaves/latest' to avoid mesos-slave restart failures on config changes
 mesos_agent_meta_cleanup: false
 

--- a/templates/conf-mesos.j2
+++ b/templates/conf-mesos.j2
@@ -8,6 +8,15 @@ LOGS={{mesos_log_location}}
 ULIMIT="{{mesos_ulimit}}"
 ZK="{{ mesos_zookeeper_masters }}"
 
+{% if mesos_ssl_enabled %}
+export LIBPROCESS_SSL_ENABLED=true
+export LIBPROCESS_SSL_SUPPORT_DOWNGRADE={{ mesos_ssl_support_downgrade | ternary('true', 'false')}}
+export LIBPROCESS_SSL_KEY_FILE={{ mesos_ssl_key_file }}
+export LIBPROCESS_SSL_CERT_FILE={{ mesos_ssl_cert_file }}
+export LIBPROCESS_SSL_VERIFY_CERT=false
+export LIBPROCESS_SSL_REQUIRE_CERT=false
+
+{% endif %}
 # mesos env variables
 # see http://mesos.apache.org/documentation/latest/configuration/
 export MESOS_HOSTNAME="{{ mesos_hostname }}"


### PR DESCRIPTION
This PR adds SSL-related [configuration settings](http://mesos.apache.org/documentation/latest/configuration/) in _/etc/default/mesos_ when `mesos_ssl_enabled` is true.