### PR TITLE
Update epel-release RPM version

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,7 +3,7 @@ os_version_major: "{{ ansible_distribution_major_version }}"
 # EPEL repository released packaged per OS version
 epel_releases:
   '6': 'epel-release-6-8.noarch.rpm'
-  '7': 'e/epel-release-7-9.noarch.rpm'
+  '7': 'e/epel-release-7-10.noarch.rpm'
 
 # Mesosphere released packaged per OS version
 mesosphere_releases:


### PR DESCRIPTION
The available release for epel-release is now at 7-10.

https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm

On the same topic, also wondering if it might be worth pointing to https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm in order to avoid future release version changes...?

### Short description:

I found the following issue(s) or bug(s):
  - Deployment fails as epel-release-7-9.noarch.rpm is not available anymore.  Needs to be bumped to 7-10.
