### PR TITLE
Remove .travis specific docker version constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: required
 
 env:
-  global:
-    # https://github.com/travis-ci/travis-ci/issues/6461#issuecomment-239577306
-    DOCKER_VERSION: "1.9.1-0~trusty"
   matrix:
     - distro: ernestasposkus/centos7
       init: /usr/lib/systemd/systemd
@@ -22,11 +19,7 @@ services:
   - docker
 
 before_install:
-  # Downgrade to specific version of Docker engine.
   - sudo apt-get update
-  - sudo apt-get remove docker-engine -yq
-  - sudo apt-get install docker-engine=$DOCKER_VERSION -yq --no-install-suggests --no-install-recommends --force-yes -o Dpkg::Options::="--force-confnew"
-
   # Pull container.
   - 'sudo docker pull ${distro}:latest'
 

--- a/tests/dependencies.yml
+++ b/tests/dependencies.yml
@@ -2,6 +2,24 @@
 - hosts: localhost
   connection: local
   remote_user: root
+  tasks:
+    - name: installing repo for Java 8 in Ubuntu
+      apt_repository: repo='ppa:openjdk-r/ppa'
+      when:
+        - ansible_os_family == 'Debian'
+
+- hosts: localhost
+  connection: local
+  remote_user: root
   roles:
     - role: geerlingguy.java
+      java_packages:
+        - openjdk-8-jdk
+      when: ansible_os_family == 'Debian'
+
+    - role: geerlingguy.java
+      java_packages:
+        - java-1.8.0-openjdk
+      when: ansible_os_family == 'RedHat'
+
     - role: AnsibleShipyard.ansible-zookeeper


### PR DESCRIPTION
Due to failing build


```
The command "sudo apt-get install docker-engine=$DOCKER_VERSION -yq --no-install-suggests --no-install-recommends --force-yes -o Dpkg::Options::="--force-confnew"" failed and exited with 100 during .
```